### PR TITLE
Mover algumas matérias de nicho para optativas

### DIFF
--- a/optativas/computacao-grafica.md
+++ b/optativas/computacao-grafica.md
@@ -2,7 +2,7 @@
 código: INE5420
 nome: Computação Gráfica
 H/A: 72
-status: mantido
+status: alterado
 ---
 
 #### Ementa:

--- a/optativas/inteligencia-artificial.md
+++ b/optativas/inteligencia-artificial.md
@@ -2,7 +2,7 @@
 código: INE5430
 nome: Inteligência Artificial
 H/A: 72
-status: mantido
+status: alterado
 ---
 
 #### Ementa:

--- a/optativas/sistemas-multimidia.md
+++ b/optativas/sistemas-multimidia.md
@@ -2,7 +2,7 @@
 código: INE5431
 nome: Sistemas Multimídia
 H/A: 72
-status: mantido
+status: alterado
 ---
 
 #### Ementa:


### PR DESCRIPTION
Como notado em #4, em uma conversa com o centro acadêmico e o PET do curso, concluímos que algumas das matérias obrigatórias são matérias de nicho (que interessam apenas a uma parcela dos estudantes e não são relevantes para os demais) e deveriam ser movidas de obrigatórias para optativas. Não há necessidade de alteração nas ementas.

Isso abre mais horas livres no currículo e também potencial para um melhor rendimento dos alunos na matéria, já que os matriculados devem ter mais foco e interesse numa matéria feita por vontade própria do que numa matéria imposta que não lhes é interessante.
